### PR TITLE
Fix build path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,7 @@ jobs:
               uses: actions/download-artifact@v2
               with:
                   name: build
+                  path: build
 
             # https://github.com/marketplace/actions/deploy-to-github-pages
             - name: Deploy to Github Pages


### PR DESCRIPTION
Archived artifact isn't the build directory, it's the contents. Need to download artifact and put it back in build directory for deployment.